### PR TITLE
Replace `/n` sequences with OS specific EOL markers

### DIFF
--- a/JavaScript/2-writeFileSync.js
+++ b/JavaScript/2-writeFileSync.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const fs = require('fs');
+const { EOL } = require('os');
 
 const data = fs.readFileSync('1-readFileSync.js', 'utf8');
-const lines = data.split('\n').filter(line => !!line);
-fs.writeFileSync('1-readFileSync.txt', lines.join('\n'));
+const lines = data.split(EOL).filter(line => !!line);
+fs.writeFileSync('1-readFileSync.txt', lines.join(EOL));

--- a/JavaScript/3-async.js
+++ b/JavaScript/3-async.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const fs = require('fs');
+const { EOL } = require('os');
 
 fs.readFile('1-readFileSync.js', 'utf8', (err, data) => {
   if (err) throw err;
   console.log(`File size: ${data.length}`);
-  const lines = data.split('\n').filter(line => !!line);
-  const content = lines.join('\n');
+  const lines = data.split(EOL).filter(line => !!line);
+  const content = lines.join(EOL);
   fs.writeFile('1-readFileSync.txt', content, err => {
     if (err) throw err;
     console.log(`New file size: ${content.length}`);


### PR DESCRIPTION
Examples 2 and 3 will yield the same result on CRLF & LF systems. I saw confusion among beginners because of this.